### PR TITLE
Improves CLI error output when provided Mautic URL is invalid

### DIFF
--- a/whitelabeler.php
+++ b/whitelabeler.php
@@ -843,7 +843,7 @@ class Whitelabeler {
 	    // Verify the URL in config.txt is correct
 	    $url = $this->findMauticUrl($config_vals['url']);
 	    if ( $url['status'] != 1 ) {
-	        $errors[] = 'Invalid URL provided.';
+	        $errors[] = 'Invalid URL provided. '.$url['message'];
 	    }
 
 	    // Verify that a COMPANY name is defined in config.txt


### PR DESCRIPTION
A simple adjustment that outputs more detailed information when an Invalid URL is provided