### PR TITLE
Adds support for absolute paths for config file and image files

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This will allow you to whitelabel using a specific file located in the `assets` 
 sudo -u www-data php cli.php --whitelabel --config=/path/to/specific_file.json
 ```
 
-This will allow you to whitelabel using a JSON file located somewhere other than the `assets` folder.
+This will allow you to whitelabel using a JSON file located somewhere other than the `assets` folder. Absolute paths with a leading `/` are recommended but paths relative to the `assets` folder with `..` should work as well.
 
 #### Backup
 

--- a/cli.php
+++ b/cli.php
@@ -114,25 +114,43 @@ if ( count($argv) > 1 ) {
 			} else {
 				$favicon = $config['login_logo'];
 			}
-			
+
+			if( substr( $favicon, 0, 1 ) == '/' ) {
+				$favicon = $favicon;
+			} else {
+				$favicon = __DIR__.'/assets/'.$favicon;
+			}
+
+			if( substr( $config['sidebar_logo'], 0, 1 ) == '/' ) {
+				$sidebar_logo = $config['sidebar_logo'];
+			} else {
+				$sidebar_logo = __DIR__.'/assets/'.$config['sidebar_logo'];
+			}
+
+			if( substr( $config['login_logo'], 0, 1 ) == '/' ) {
+				$login_logo = $config['login_logo'];
+			} else {
+				$login_logo = __DIR__.'/assets/'.$config['login_logo'];
+			}
+
 			$logos = $whitelabeler->replaceImages(
 				$config['path'],
 				$config['url'],
 				$version['version'],
-				__DIR__.'/assets/'.$config['sidebar_logo'],
+				$sidebar_logo,
 				$config['sidebar_logo_width'],
 				array(
 					'top' => $config['sidebar_logo_margin_top'],
 					'right' => $config['sidebar_logo_margin_right'],
 					'left' => $config['sidebar_logo_margin_left']
 				),
-				__DIR__.'/assets/'.$config['login_logo'],
+				$login_logo,
 				$config['login_logo_width'],
 				array(
 					'top' => $config['login_logo_margin_top'],
 					'bottom' => $config['login_logo_margin_bottom']
 				),
-				__DIR__.'/assets/'.$favicon
+				$favicon
 			);
 			
 			if ( $logos['status'] == 1 ) {

--- a/whitelabeler.php
+++ b/whitelabeler.php
@@ -26,7 +26,11 @@ class Whitelabeler {
 */
 	public function loadJsonConfig($file) {
 		$config = array();
-		if ( file_exists( __DIR__.'/assets/'.$file ) ) {
+
+		if ( substr( $file, 0, 1 ) == '/' && file_exists( $file ) ) {
+			$config = json_decode(file_get_contents($file), true);
+			return $config;
+		} elseif ( file_exists( __DIR__.'/assets/'.$file ) ) {
 			$config = json_decode(file_get_contents(__DIR__.'/assets/'.$file), true);
 			return $config;
 		} else {
@@ -209,7 +213,9 @@ class Whitelabeler {
 	|--------------------------------------------------------------------------
 	*/
 	public function imageExists($image) {
-		if ( file_exists(__DIR__.'/assets/'.$image) ) {
+		if ( substr( $image, 0, 1 ) == '/' && file_exists( $image ) ) {
+			return true;
+		} elseif ( file_exists(__DIR__.'/assets/'.$image) ) {
 			return true;
 		} else {
 			return false;


### PR DESCRIPTION
This pull request adds the ability for absolute paths to be specified for the configuration file and image files. The main use-case I see for this behavior is being able to keep the config file and image assets in git repo outside of the `mautic-whitelabeler` repo. This should have no effect on existing config files that rely on paths relative to the assets directory.

Absolute paths will be used instead only if the path (image files or config file) has a leading `/`.