### PR TITLE
fix(2.15.1): improve sidebar_image display

### DIFF
--- a/templates/2.15.1/app/bundles/CoreBundle/Views/LeftPanel/index.html.php
+++ b/templates/2.15.1/app/bundles/CoreBundle/Views/LeftPanel/index.html.php
@@ -13,7 +13,7 @@ $extraMenu = $view['menu']->render('extra');
 <!-- start: sidebar-header -->
 <div class="sidebar-header">
     <!-- brand -->
-    <a class="mautic-brand<?php echo (!empty($extraMenu)) ? ' pull-left pl-0 pr-0' : ''; ?>" href="#">
+    <a class="mautic-brand<?php echo (!empty($extraMenu)) ? ' pull-left pl-0 pr-0' : ''; ?>" href="#" style="text-align:center; padding:0;">
 		<img src="{{sidebar_image}}" style="width:100%; max-width:{{sidebar_width}}px; margin:{{margin_top}}px {{margin_right}}px 0 {{margin_left}}px;" />
     </a>
     <?php if (!empty($extraMenu)): ?>


### PR DESCRIPTION
There is a difference between the `2.15.0` and `2.15.1` templates that is affecting the displayed width of the sidebar_image.

This updates the 2.15.1 templatge to the previous behaviour in 2.15.0.

Closes #65