### PR TITLE
fix(2.15.1+): :children_crossing: re-add {{sidebar_image}} padding

### DIFF
--- a/templates/2.15.1/app/bundles/CoreBundle/Views/LeftPanel/index.html.php
+++ b/templates/2.15.1/app/bundles/CoreBundle/Views/LeftPanel/index.html.php
@@ -13,8 +13,8 @@ $extraMenu = $view['menu']->render('extra');
 <!-- start: sidebar-header -->
 <div class="sidebar-header">
     <!-- brand -->
-    <a class="mautic-brand<?php echo (!empty($extraMenu)) ? ' pull-left pl-0 pr-0' : ''; ?>" href="#">
-		<img src="{{sidebar_image}}" style="width:100%; max-width:{{sidebar_width}}px; margin:{{margin_top}}px {{margin_right}}px 0 {{margin_left}}px;" />
+    <a class="mautic-brand<?php echo (!empty($extraMenu)) ? ' pull-left pl-0 pr-0' : ''; ?>" href="#" style="text-align:center; padding:0;">
+        <img src="{{sidebar_image}}" style="width:100%; max-width:{{sidebar_width}}px; margin:{{margin_top}}px {{margin_right}}px 0 {{margin_left}}px;" />
     </a>
     <?php if (!empty($extraMenu)): ?>
         <div class="dropdown extra-menu">

--- a/templates/2.15.2/app/bundles/CoreBundle/Views/LeftPanel/index.html.php
+++ b/templates/2.15.2/app/bundles/CoreBundle/Views/LeftPanel/index.html.php
@@ -13,8 +13,8 @@ $extraMenu = $view['menu']->render('extra');
 <!-- start: sidebar-header -->
 <div class="sidebar-header">
     <!-- brand -->
-    <a class="mautic-brand<?php echo (!empty($extraMenu)) ? ' pull-left pl-0 pr-0' : ''; ?>" href="#">
-		<img src="{{sidebar_image}}" style="width:100%; max-width:{{sidebar_width}}px; margin:{{margin_top}}px {{margin_right}}px 0 {{margin_left}}px;" />
+    <a class="mautic-brand<?php echo (!empty($extraMenu)) ? ' pull-left pl-0 pr-0' : ''; ?>" href="#" style="text-align:center; padding:0;">
+        <img src="{{sidebar_image}}" style="width:100%; max-width:{{sidebar_width}}px; margin:{{margin_top}}px {{margin_right}}px 0 {{margin_left}}px;" />
     </a>
     <?php if (!empty($extraMenu)): ?>
         <div class="dropdown extra-menu">


### PR DESCRIPTION
There is a difference between the `2.15.0` and `2.15.1`/`2.15.2`
templates that is limiting the effective width of the `{{sidebar_image}}`.

This updates the `2.15.1` and `2.15.2` templates to match `2.15.0`.

Closes #65