### PR TITLE
Change ico check, to be compatible out of the box with mautic docker v3

### DIFF
--- a/whitelabeler.php
+++ b/whitelabeler.php
@@ -521,7 +521,7 @@ class Whitelabeler {
 		require_once('vendor/chrisjean/php-ico/class-php-ico.php');
 
 		// If favicon is .ico, move/copy the file
-		if ( exif_imagetype($favicon_image) == 17 ) {
+		if ( strpos(finfo_file(finfo_open(FILEINFO_MIME_TYPE),$favicon_image), 'ico') ) { // check if the mimetype of picture contain ico (match all image/*ico* )
 			copy($favicon_image, $path.'/favicon.ico');
 			copy($path.'/favicon.ico', $media_images.'/favicon.ico');
 		// convert to .ico and save.


### PR DESCRIPTION
On fresh install of mautic docker v3 (debian 10) , the error "Call to undefined function exif_imagetype()" crash the upload of logo.
GD library is installed ... ( ? don't find why the function is undefined )

So I use another method to check the icon type mime.

Now, no error on upload